### PR TITLE
Add underscore to alpha_dash rule to be consistent with laravel definition.

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -16,7 +16,7 @@ export default {
     after_or_equal: ({ value, params }) => b(new Date(value) >= new Date(params[0])),
     
     alpha: ({ value }) => b(typeof value === 'string') && !/[^a-z]/i.test(value),
-    alpha_dash: ({ value }) => b(typeof value === 'string') && /^[A-Za-z\-]+$/i.test(value),
+    alpha_dash: ({ value }) => b(typeof value === 'string') && /^[A-Za-z\-_]+$/i.test(value), // Unicode is still missing!
     alpha_num: ({ value }) => b(typeof value === 'string') && /^[a-z0-9]+$/i.test(value),
     
     array: ({ value }) => Array.isArray(value),

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -174,6 +174,11 @@ describe('Rules', () => {
             result: true,
         },
         {
+            desc: 'underscore alpha string',
+            value: "test_test",
+            result: true,
+        },
+        {
             desc: 'string with spaces',
             value: "test f",
             result: false,


### PR DESCRIPTION
I fixed the alpha_num rule to also allow underscores. This is the same definition as laraval uses.