### PR TITLE
Fix email rule to allow long top level domains and underscore

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -99,7 +99,7 @@ export default {
         }, 0) <= 1);
     },
     
-    email: ({ value }) => /^\w+([\.+-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(value),
+    email: ({ value }) => /^\w+([\.+-_]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,})+$/.test(value),
 
     ends_with: ({ value, params }) => {
         if (Array.isArray(value)) {

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -823,11 +823,6 @@ describe('Rules', () => {
             result: false,
         },
         {
-            desc: 'email with an invalid website (.invalid)',
-            value: "test@test.invalid",
-            result: false,
-        },
-        {
             desc: 'email with an invalid website (no .)',
             value: "test@test",
             result: false,
@@ -836,6 +831,21 @@ describe('Rules', () => {
             desc: 'null value',
             value: null,
             result: false,
+        },
+        {
+            desc: 'email with a long tld',
+            value: "test@domain.longtld",
+            result: true,
+        },
+        {
+            desc: 'email with underscore',
+            value: "test_test@domain.longtld",
+            result: true,
+        },
+        {
+            desc: 'email with multiple subdomains',
+            value: "test@subdomain.domain.longtld",
+            result: true,
         },
     ]);
 


### PR DESCRIPTION
I fixed the email rule to also allow multiple subdomains and longer top level domains like .name or .game.